### PR TITLE
Fix secondary pages when using custom padding

### DIFF
--- a/src/components/screens/InitialScreen.tsx
+++ b/src/components/screens/InitialScreen.tsx
@@ -121,7 +121,7 @@ const InitialScreen = ({ setIsWalletModalOpen, isWalletModalOpen }: Props) => {
       </form>
 
       {selectPairSelector !== null ? (
-        <div className="absolute top-0 h-full w-full bg-jupiter-bg rounded-lg overflow-hidden">
+        <div className="absolute top-0 left-0 h-full w-full bg-jupiter-bg rounded-lg overflow-hidden">
           <FormPairSelector
             onSubmit={onSelectMint}
             tokenInfos={availableMints}
@@ -131,7 +131,7 @@ const InitialScreen = ({ setIsWalletModalOpen, isWalletModalOpen }: Props) => {
       ) : null}
 
       {showRouteSelector ? (
-        <div className="absolute top-0 h-full w-full bg-jupiter-bg rounded-lg overflow-hidden">
+        <div className="absolute top-0 left-0 h-full w-full bg-jupiter-bg rounded-lg overflow-hidden">
           <RouteSelectionScreen onClose={() => setShowRouteSelector(false)} />
         </div>
       ) : null}


### PR DESCRIPTION
When you add custom padding to the Jupiter terminal, secondary pages are not aligned correctly.

```
window({
  ...
  containerStyles: { padding: "32px" }
});
```
<img width="548" alt="Screenshot 2023-07-08 at 5 56 43 PM" src="https://github.com/jup-ag/terminal/assets/82029448/eaff17b9-fbd2-469b-a26c-ea16f299ec3e">

I have added the `left-0` tailwind css class to the two secondary pages (route selector and pair selector) so that it aligns with the modal correctly.

<img width="548" alt="Screenshot 2023-07-08 at 6 01 08 PM" src="https://github.com/jup-ag/terminal/assets/82029448/7651ccbd-45f4-4b24-b846-b9c351f6c98c">


