### PR TITLE
Add support for searching tokens by mint address

### DIFF
--- a/src/components/FormPairSelector.tsx
+++ b/src/components/FormPairSelector.tsx
@@ -64,7 +64,7 @@ const FormPairSelector = ({
       })
 
     if (searchTerm) {
-      const filteredList = sortedList.filter((item) => item.symbol.toLowerCase().includes(searchTerm.toLowerCase()));
+      const filteredList = sortedList.filter((item) => item.symbol.toLowerCase().includes(searchTerm.toLowerCase()) || item.address.toLowerCase().includes(searchTerm.toLowerCase()));
       setSearchResult(filteredList);
     } else {
       setSearchResult(sortedList);


### PR DESCRIPTION
### Description
Add support for searching tokens by their mint address when searching a token in the terminal.

**Before**
<img width="440" alt="image" src="https://github.com/jup-ag/terminal/assets/20179273/8df4a933-4064-4eea-9d0a-5bbe65b4767d">

**After**
![image](https://github.com/jup-ag/terminal/assets/20179273/2a1cb8ee-ebda-4db1-bb54-6eb52986f313)
