### PR TITLE
fix: allow the passing of connection configuration options to the widget

### DIFF
--- a/src/contexts/ContextProvider.tsx
+++ b/src/contexts/ContextProvider.tsx
@@ -38,7 +38,7 @@ export const HARDCODED_WALLET_STANDARDS: { id: string; name: WalletName; url: st
 ];
 
 const noop = () => {};
-const WalletContextProvider: React.FC<PropsWithChildren<IInit>> = ({ autoConnect, endpoint, children }) => {
+const WalletContextProvider: React.FC<PropsWithChildren<IInit>> = ({ autoConnect, endpoint, endpointConfig, children }) => {
   const { networkConfiguration } = useNetworkConfiguration();
   const network = networkConfiguration as WalletAdapterNetwork;
   const selectedEndpoint: string = useMemo(() => endpoint ?? clusterApiUrl(network), [endpoint, network]);
@@ -126,7 +126,7 @@ const WalletContextProvider: React.FC<PropsWithChildren<IInit>> = ({ autoConnect
 
   return (
     <>
-      <ConnectionProvider endpoint={selectedEndpoint}>
+      <ConnectionProvider endpoint={selectedEndpoint} config={endpointConfig}>
         <ShouldWrapWalletProvider>{children}</ShouldWrapWalletProvider>
       </ConnectionProvider>
       {showWalletStatus.show && showWalletStatus.message ? (

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2,7 +2,7 @@ import { CSSProperties } from 'react';
 import { Root } from 'react-dom/client';
 import { createStore } from 'jotai';
 import { Wallet } from '@jup-ag/wallet-adapter';
-import { PublicKey, TransactionError } from '@solana/web3.js';
+import { ConnectionConfig, PublicKey, TransactionError } from '@solana/web3.js';
 import { QuoteResponseMeta, SwapMode, SwapResult } from '@jup-ag/react-hook';
 import { WalletContextState } from '@jup-ag/wallet-adapter';
 import EventEmitter from 'events';
@@ -73,6 +73,11 @@ export interface IOnRequestIxCallback {
 export interface IInit {
   /** Solana RPC endpoint */
   endpoint: string;
+  /**
+   * Configuration for instantiating a Solana RPC Connection object.
+   * [`ConnectionConfig` docs](https://solana-labs.github.io/solana-web3.js/classes/Connection.html)
+   */
+  endpointConfig?: ConnectionConfig;
   /** TODO: Update to use the new platform fee and accounts */
   platformFeeAndAccounts?: PlatformFeeAndAccounts;
   /** Configure Terminal's behaviour and allowed actions for your user */


### PR DESCRIPTION
This PR allows you to configure The Jupiter Widget's `Connection` to solana.
Fixes #76 