### PR TITLE
feat: remove usdc, usdt and jlp from ignore list and rename warning pill

### DIFF
--- a/src/components/SuggestionTags/Tags/AuthorityAndDelegatesSuggestion.tsx
+++ b/src/components/SuggestionTags/Tags/AuthorityAndDelegatesSuggestion.tsx
@@ -106,7 +106,7 @@ export const AuthorityAndDelegatesSuggestion = ({
     >
       <BasePill className={cn(isVerified ? SUGGESTION_CLASS : DANGER_CLASS)}>
         <InfoIconSVG width={10} height={10} />
-        Authority Warning
+        Token Permission
       </BasePill>
     </PopoverTooltip>
   );

--- a/src/components/SuggestionTags/hooks/useSuggestionTags.tsx
+++ b/src/components/SuggestionTags/hooks/useSuggestionTags.tsx
@@ -17,7 +17,7 @@ import { useBirdeyeRouteInfo } from './useSwapInfo';
 const HIGH_PRICE_IMPACT = 5; // 5%
 const HIGH_PRICE_DIFFERENCE = 5; // 5%
 
-const FREEZE_AUTHORITY_IGNORE_LIST = [USDC_MINT.toString(), USDT_MINT.toString(), JLP_MINT.toString()];
+const FREEZE_AUTHORITY_IGNORE_LIST: string[] = []; // Used to be USDC, USDT, JLP
 
 export const useSuggestionTags = ({
   fromTokenInfo,
@@ -73,7 +73,7 @@ export const useSuggestionTags = ({
         FREEZE_AUTHORITY_IGNORE_LIST.includes(fromTokenInfo.address) === false && // Ignore bluechip like, USDC, USDT
         (tokenExt1.freezeAuthority === SystemProgram.programId.toString()) === false // Ignore system program
       ) {
-        freeze.push(fromTokenInfo); // Only mark non-strict token, so USDC, USDT, don't get marked
+        freeze.push(fromTokenInfo); // Only mark non-strict token
       }
 
       if (tokenExt1?.permanentDelegate) {
@@ -85,7 +85,7 @@ export const useSuggestionTags = ({
         FREEZE_AUTHORITY_IGNORE_LIST.includes(toTokenInfo.address) === false && // Ignore bluechip like, USDC, USDT
         (tokenExt2.freezeAuthority === SystemProgram.programId.toString()) === false // Ignore system program
       ) {
-        freeze.push(toTokenInfo); // Only mark non-strict token, so USDC, USDT, don't get marked
+        freeze.push(toTokenInfo); // Only mark non-strict token
       }
       if (tokenExt2?.permanentDelegate) {
         permanent.push(toTokenInfo);


### PR DESCRIPTION
- remove usdc, usdt and jlp from FREEZE_AUTHORITY_IGNORE_LIST
- rename "Authority Warning" to "Token Permission"