### PR TITLE
fix: updated terminal docs link

### DIFF
--- a/src/components/AppHeader/HeaderLinks.tsx
+++ b/src/components/AppHeader/HeaderLinks.tsx
@@ -55,7 +55,7 @@ const HeaderLinks = () => {
         icon={<RepoLogo width="20" height="20" />}
       />
       <HeaderLink
-        href="https://station.jup.ag/docs/jup-terminal"
+        href="https://station.jup.ag/docs/tool-kits/terminal-walkthrough"
         isActive={false}
         external
         title={'Docs'}


### PR DESCRIPTION
### Issue
Currently Header link directs users to the wrong page of the docs. (https://station.jup.ag/docs/jup-terminal)

### Fix 
Changed the Header link to direct user to the updated documentation link (https://station.jup.ag/docs/tool-kits/terminal-walkthrough)