### PR TITLE
feat: hide wallet when enableWalletPassthrough is true

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -36,8 +36,7 @@ const Header: React.FC<{ setIsWalletModalOpen(toggle: boolean): void }> = ({ set
           >
             <RefreshSVG />
           </button>
-
-          <WalletButton setIsWalletModalOpen={setIsWalletModalOpen} />
+          {!window.Jupiter.enableWalletPassthrough && <WalletButton setIsWalletModalOpen={setIsWalletModalOpen} />}
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Changelog

Hide wallet in terminal when `enableWalletPassthrough` is set to `true`

Reason: this to avoid having duplicated wallet showing in integrator app

# Example
<img width="679" alt="Screenshot 2025-05-16 at 5 51 11 PM" src="https://github.com/user-attachments/assets/604f1f36-e000-4a06-aa7f-cb6f827eec4f" />
