### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+<a href="https://www.readme-i18n.com/jup-ag/terminal?lang=zh">中文</a> | 
+<a href="https://www.readme-i18n.com/jup-ag/terminal?lang=es">Español</a> | 
+<a href="https://www.readme-i18n.com/jup-ag/terminal?lang=pt">Português</a> | 
+<a href="https://www.readme-i18n.com/jup-ag/terminal?lang=fr">français</a> | 
+<a href="https://www.readme-i18n.com/jup-ag/terminal?lang=de">Deutsch</a> | 
+<a href="https://www.readme-i18n.com/jup-ag/terminal?lang=ko">한국어</a> | 
+<a href="https://www.readme-i18n.com/jup-ag/terminal?lang=ru">Русский</a> | 
+<a href="https://www.readme-i18n.com/jup-ag/terminal?lang=ja">日本語</a>
+---
+
 # Jupiter Terminal
 
 Jupiter Terminal is an open-sourced, lite version of Jupiter that provides end-to-end swap flow by linking it in your HTML.


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions:  Chinese, Russian, Spanish, Japanese, French, Portuguese, German, and Korean.