### PR TITLE
🐛 Ensure close button is visible in modal and widget mode with default background color

### DIFF
--- a/src/components/screens/SwappingScreen.tsx
+++ b/src/components/screens/SwappingScreen.tsx
@@ -211,7 +211,7 @@ const SwappingScreen = () => {
           </JupButton>
 
           {displayMode !== 'integrated' ? (
-            <JupButton size="lg" className="w-full mt-4 disabled:opacity-50 leading-none !max-h-14" onClick={onClose}>
+            <JupButton size="lg" className="w-full mt-4 disabled:opacity-50 leading-none !max-h-14 !text-white/75 bg-v2-background-dark" onClick={onClose}>
               <span className="text-sm">Close</span>
             </JupButton>
           ) : null}


### PR DESCRIPTION
By default with black background, the close button (after successful swap) is not visible. This PR adds a text and background color so it will be.

Before:
<img width="372" alt="Screenshot 2025-06-05 at 4 37 41 pm" src="https://github.com/user-attachments/assets/d49d86f4-ecb6-455c-8640-366bf6ffdc49" />


After:
<img width="370" alt="Screenshot 2025-06-05 at 4 42 59 pm" src="https://github.com/user-attachments/assets/4fd84740-ff01-4732-a2f4-e77447eb141f" />

