### PR TITLE
fix: cleanup useQuoteQuery and remove stray console.log

### DIFF
--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -137,8 +137,8 @@ const Form: React.FC<{
         setLastSwapResult,
       });
     } catch (error) {
-      console.log('Swap error', error);
-    } finally{
+      // Error handling is done via setLastSwapResult in ultraSwapMutation
+    } finally {
       setScreen('Swapping');
     }
   }, [wallet, quoteResponseMeta, ultraSwapMutation, fromTokenInfo, toTokenInfo, setTxStatus, setLastSwapResult,setScreen]);

--- a/src/queries/useQuoteQuery.ts
+++ b/src/queries/useQuoteQuery.ts
@@ -1,4 +1,4 @@
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { UltraSwapQuoteParams, ultraSwapService } from 'src/data/UltraSwapService';
 import { FormattedUltraQuoteResponse } from 'src/entity/FormattedUltraQuoteResponse';
 import { create } from 'superstruct';
@@ -12,17 +12,16 @@ export const useQuoteQuery = (initialParams: UltraSwapQuoteParams, shouldRefetch
         return null;
       }
       try {
-        let params =initialParams;
+        let params = initialParams;
         if (params.excludeDexes && params.excludeDexes.length > 0) {
-          params ={
+          // TODO: Consider making excludeRouters configurable instead of hardcoded
+          params = {
             ...initialParams,
-            excludeRouters:[
-              'okx','dflow','hashflow','jupiterz'
-            ]
-          }
+            excludeRouters: ['okx', 'dflow', 'hashflow', 'jupiterz'],
+          };
         }
         const response = await ultraSwapService.getQuote(params, signal);
-        const quoteResponse = create(response, FormattedUltraQuoteResponse, 'conver FormattedUltraQuoteResponse Error');
+        const quoteResponse = create(response, FormattedUltraQuoteResponse, 'convert FormattedUltraQuoteResponse Error');
         return {
           quoteResponse,
           original: response,


### PR DESCRIPTION
## Summary
This PR cleans up minor issues in the codebase:

### Changes
- **Fix typo**: `'conver'` → `'convert'` in superstruct error message
- **Remove unused import**: `keepPreviousData` was imported but never used
- **Fix code formatting**: Consistent spacing around assignments
- **Remove console.log**: Removed stray `console.log('Swap error', error)` from Form.tsx
- **Add TODO**: Note about hardcoded `excludeRouters` array for future consideration

### Files Changed
- `src/queries/useQuoteQuery.ts`
- `src/components/Form.tsx`

### Testing
- No functional changes, purely cleanup
- Verified builds successfully