### PR TITLE
feat: export TypeScript types for better DX

### DIFF
--- a/src/npmlibary.tsx
+++ b/src/npmlibary.tsx
@@ -1,5 +1,7 @@
 import { init as ogInit, resume, close, appProps, syncProps } from './library';
-import { IInit } from './types';
+import { IInit, FormProps, WidgetPosition, WidgetSize, SwapMode, DEFAULT_EXPLORER, JupiterPlugin } from './types';
+import { IForm, QuoteResponse, SwapResult, SwappingStatus } from './contexts/SwapContext';
+import { Screens } from './contexts/ScreenProvider';
 
 import { RenderJupiter } from '.';
 
@@ -15,4 +17,24 @@ async function init(props: IInit) {
   await ogInit(props);
 }
 
+// Runtime exports
 export { init, resume, close, appProps, syncProps };
+
+// Type exports for TypeScript consumers
+export type {
+  // Main configuration types
+  IInit,
+  FormProps,
+  JupiterPlugin,
+  // Display options
+  WidgetPosition,
+  WidgetSize,
+  SwapMode,
+  DEFAULT_EXPLORER,
+  // Callback types
+  IForm,
+  QuoteResponse,
+  SwapResult,
+  SwappingStatus,
+  Screens,
+};


### PR DESCRIPTION
## Summary
Export TypeScript types so integrators get proper autocomplete and type checking.

### Before
```typescript
import { init } from '@jup-ag/plugin';
// ❌ No type exports - integrators have to define their own types or use 'any'
```

### After
```typescript
import { init } from '@jup-ag/plugin';
import type { IInit, FormProps, QuoteResponse, SwapResult } from '@jup-ag/plugin';

// ✅ Full autocomplete and type checking
const config: IInit = {
  formProps: { /* autocomplete works */ },
  onSuccess: ({ txid, swapResult }) => { /* typed! */ }
};
```

### Exported Types

**Main configuration:**
- `IInit` - Main initialization options
- `FormProps` - Swap form configuration  
- `JupiterPlugin` - Window.Jupiter interface

**Display options:**
- `WidgetPosition` - Widget placement options
- `WidgetSize` - Widget size options
- `SwapMode` - ExactIn/ExactOut/ExactInOrOut
- `DEFAULT_EXPLORER` - Explorer options

**Callback types:**
- `IForm` - Form state passed to onFormUpdate
- `QuoteResponse` - Quote data in callbacks
- `SwapResult` - Result passed to onSuccess
- `SwappingStatus` - Transaction status
- `Screens` - Screen state for onScreenUpdate

### Impact
Better DX for TypeScript users with zero runtime changes.