### PR TITLE
fix: make excludeRouters configurable instead of hardcoded

### DIFF
--- a/src/contexts/SwapContext.tsx
+++ b/src/contexts/SwapContext.tsx
@@ -206,6 +206,7 @@ export const SwapContextProvider = (props: PropsWithChildren<IInit>) => {
       referralAccount: formProps.referralAccount,
       referralFee: formProps.referralFee,
       excludeDexes: formProps.excludeDexes,
+      excludeRouters: formProps.excludeRouters,
     },
     // Stop refetching when transaction is in progress
     !txStatus,

--- a/src/queries/useQuoteQuery.ts
+++ b/src/queries/useQuoteQuery.ts
@@ -1,7 +1,13 @@
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { UltraSwapQuoteParams, ultraSwapService } from 'src/data/UltraSwapService';
 import { FormattedUltraQuoteResponse } from 'src/entity/FormattedUltraQuoteResponse';
 import { create } from 'superstruct';
+
+/**
+ * Default routers to exclude when excludeDexes is specified.
+ * These are third-party aggregators that may not respect DEX exclusions.
+ */
+const DEFAULT_EXCLUDED_ROUTERS = ['okx', 'dflow', 'hashflow', 'jupiterz'];
 
 export const useQuoteQuery = (initialParams: UltraSwapQuoteParams, shouldRefetch: boolean = true) => {
   const { amount } = initialParams;
@@ -12,17 +18,19 @@ export const useQuoteQuery = (initialParams: UltraSwapQuoteParams, shouldRefetch
         return null;
       }
       try {
-        let params =initialParams;
-        if (params.excludeDexes && params.excludeDexes.length > 0) {
-          params ={
+        let params = initialParams;
+
+        // If excludeDexes is specified, also exclude routers that may bypass DEX exclusions
+        // Users can override this by explicitly providing excludeRouters
+        if (params.excludeDexes && params.excludeDexes.length > 0 && !params.excludeRouters) {
+          params = {
             ...initialParams,
-            excludeRouters:[
-              'okx','dflow','hashflow','jupiterz'
-            ]
-          }
+            excludeRouters: DEFAULT_EXCLUDED_ROUTERS,
+          };
         }
+
         const response = await ultraSwapService.getQuote(params, signal);
-        const quoteResponse = create(response, FormattedUltraQuoteResponse, 'conver FormattedUltraQuoteResponse Error');
+        const quoteResponse = create(response, FormattedUltraQuoteResponse, 'convert FormattedUltraQuoteResponse Error');
         return {
           quoteResponse,
           original: response,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -40,8 +40,14 @@ export interface FormProps {
   /** Referral fee to use for the swap */
   referralFee?: number;
 
-  /** Exclude DEXes */
+  /** Exclude DEXes from routing */
   excludeDexes?: string[];
+  /** 
+   * Exclude specific routers (e.g., 'okx', 'dflow', 'hashflow', 'jupiterz').
+   * If not provided but excludeDexes is set, defaults to excluding third-party aggregators
+   * that may not respect DEX exclusions.
+   */
+  excludeRouters?: string[];
 
 }
 


### PR DESCRIPTION
## Summary
When `excludeDexes` is specified, the plugin previously added a hardcoded list of `excludeRouters` without any way to override or opt out. This PR makes the behavior configurable.

### Problem
```typescript
// Before: User has no control over router exclusions
init({
  formProps: {
    excludeDexes: ['Raydium'], // Always adds hardcoded excludeRouters
  }
});
```

### Solution
```typescript
// After: User has full control
init({
  formProps: {
    excludeDexes: ['Raydium'],
    excludeRouters: ['okx'], // Override defaults
  }
});

// Or opt out of default router exclusions
init({
  formProps: {
    excludeDexes: ['Raydium'],
    excludeRouters: [], // Empty array = no router exclusions
  }
});
```

### Changes
- **types/index.d.ts**: Add `excludeRouters` to `FormProps` with JSDoc
- **SwapContext.tsx**: Pass `excludeRouters` to quote query
- **useQuoteQuery.ts**: 
  - Only apply default excludeRouters if user doesn't specify their own
  - Extract defaults to `DEFAULT_EXCLUDED_ROUTERS` constant
  - Also includes fixes from PR #217 (typo, unused import)

### Backwards Compatible
Existing integrations work identically - the default behavior is preserved when `excludeRouters` is not specified.