### PR TITLE
fix: use stable bundle name in dev mode to avoid CDN mismatch

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,7 @@ NEXT_PUBLIC_CLUSTER=mainnet-beta
 
 # Local development is similar as next public preview
 NEXT_PUBLIC_IS_NEXT_PREVIEW=true
+
+# Enable plugin dev mode - uses local builds instead of CDN
+# This allows version bumps without waiting for CDN upload
+NEXT_PUBLIC_IS_PLUGIN_DEV=true

--- a/DEVELOPER_NOTES.md
+++ b/DEVELOPER_NOTES.md
@@ -34,6 +34,10 @@ pnpm dev                # Start dev server - homepage works!
 This solves the "version mismatch" issue where bumping package.json version 
 would cause the homepage to try loading files that don't exist on CDN yet.
 
+**Vercel previews:** Automatically detected via `VERCEL_ENV=preview`. 
+The `vercel.json` runs `build-widget:dev` before Next.js build, so PR previews 
+load the new code from the preview URL instead of CDN.
+
 There's a few point of entry for Plugin, and each has specific reasons:
 
 - https://github.com/jup-ag/plugin/blob/main/src/index.tsx (RenderJupiter)

--- a/DEVELOPER_NOTES.md
+++ b/DEVELOPER_NOTES.md
@@ -1,7 +1,31 @@
 # Developer Notes
 
-To develop, `pnpm i && pnpm dev`
-To build, `pnpm build-widget`
+## Quick Start
+
+```bash
+pnpm i
+pnpm dev
+```
+
+## Building
+
+```bash
+# Production build (versioned: plugin-1.0.x.js)
+pnpm build-widget
+
+# Dev build (stable name: plugin-dev.js) - for local testing
+NEXT_PUBLIC_IS_PLUGIN_DEV=true pnpm build-widget
+```
+
+## Dev Mode Bundle Loading
+
+When `NEXT_PUBLIC_IS_PLUGIN_DEV=true` is set (in `.env` or environment):
+- Webpack outputs to `plugin-dev.js` instead of `plugin-{version}.js`
+- The loader uses the local build instead of fetching from CDN
+- You can bump versions freely without breaking the homepage
+
+This solves the "version mismatch" issue where bumping package.json version 
+would cause the homepage to try loading files that don't exist on CDN yet.
 
 There's a few point of entry for Plugin, and each has specific reasons:
 

--- a/DEVELOPER_NOTES.md
+++ b/DEVELOPER_NOTES.md
@@ -10,33 +10,29 @@ pnpm dev
 ## Building
 
 ```bash
-# Dev build (stable name: plugin-dev.js) - for local testing
-pnpm build-widget:dev
-
-# Production build (versioned: plugin-1.0.x.js) - for publishing
-pnpm build-widget
+pnpm build-widget    # Build versioned bundle (plugin-1.0.x.js) to /public/
 ```
 
-## Dev Mode Bundle Loading
+## Local Development
 
-When using `pnpm build-widget:dev`:
-- Webpack outputs to `plugin-dev.js` instead of `plugin-{version}.js`
-- The homepage loads the local build instead of fetching from CDN
-- You can bump versions freely without breaking the homepage
+The `.env` file has `NEXT_PUBLIC_IS_PLUGIN_DEV=true` which tells the app to 
+load bundles from local `/public/` instead of CDN.
 
-**Typical dev workflow:**
+**Workflow:**
 ```bash
-pnpm build-widget:dev   # Build once with stable name
-pnpm dev                # Start dev server - homepage works!
-# Make changes, bump version, rebuild - still works
+pnpm build-widget   # Build once (creates /public/plugin-1.0.x.js)
+pnpm dev            # Homepage loads from localhost, not CDN
+# Bump version, rebuild, still works - loads new version from /public/
 ```
 
-This solves the "version mismatch" issue where bumping package.json version 
-would cause the homepage to try loading files that don't exist on CDN yet.
+## Vercel Previews
 
-**Vercel previews:** Automatically detected via `VERCEL_ENV=preview`. 
-The `vercel.json` runs `build-widget:dev` before Next.js build, so PR previews 
-load the new code from the preview URL instead of CDN.
+Automatically handled:
+- `vercel.json` runs `build-widget` before Next.js build
+- `NEXT_PUBLIC_VERCEL_ENV=preview` is set automatically by Vercel
+- App detects preview mode and loads from preview URL instead of CDN
+
+**Result:** PR previews always test the new code, no CDN needed.
 
 There's a few point of entry for Plugin, and each has specific reasons:
 

--- a/DEVELOPER_NOTES.md
+++ b/DEVELOPER_NOTES.md
@@ -10,19 +10,26 @@ pnpm dev
 ## Building
 
 ```bash
-# Production build (versioned: plugin-1.0.x.js)
-pnpm build-widget
-
 # Dev build (stable name: plugin-dev.js) - for local testing
-NEXT_PUBLIC_IS_PLUGIN_DEV=true pnpm build-widget
+pnpm build-widget:dev
+
+# Production build (versioned: plugin-1.0.x.js) - for publishing
+pnpm build-widget
 ```
 
 ## Dev Mode Bundle Loading
 
-When `NEXT_PUBLIC_IS_PLUGIN_DEV=true` is set (in `.env` or environment):
+When using `pnpm build-widget:dev`:
 - Webpack outputs to `plugin-dev.js` instead of `plugin-{version}.js`
-- The loader uses the local build instead of fetching from CDN
+- The homepage loads the local build instead of fetching from CDN
 - You can bump versions freely without breaking the homepage
+
+**Typical dev workflow:**
+```bash
+pnpm build-widget:dev   # Build once with stable name
+pnpm dev                # Start dev server - homepage works!
+# Make changes, bump version, rebuild - still works
+```
 
 This solves the "version mismatch" issue where bumping package.json version 
 would cause the homepage to try loading files that don't exist on CDN yet.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "lint": "next lint",
     "format:fix": "prettier --write src",
     "build-widget": "NODE_ENV=production MODE=widget webpack",
-    "build-widget:dev": "NODE_ENV=production MODE=widget NEXT_PUBLIC_IS_PLUGIN_DEV=true webpack",
     "analyse": "NODE_ENV=production MODE=widget ANALYSE=true webpack"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "next lint",
     "format:fix": "prettier --write src",
     "build-widget": "NODE_ENV=production MODE=widget webpack",
+    "build-widget:dev": "NODE_ENV=production MODE=widget NEXT_PUBLIC_IS_PLUGIN_DEV=true webpack",
     "analyse": "NODE_ENV=production MODE=widget ANALYSE=true webpack"
   },
   "files": [

--- a/src/library.tsx
+++ b/src/library.tsx
@@ -14,7 +14,11 @@ import { ShadowDomContainer } from './components/ShadowDomContainer';
 
 const containerId = 'jupiter-plugin-instance';
 const packageJson = require('../package.json');
-const bundleName = `plugin-${packageJson.version}`;
+
+// Use stable name in dev mode to avoid CDN version mismatch
+const bundleName = process.env.NEXT_PUBLIC_IS_PLUGIN_DEV 
+  ? 'plugin-dev' 
+  : `plugin-${packageJson.version}`;
 
 const scriptDomain =
   (() => {

--- a/src/library.tsx
+++ b/src/library.tsx
@@ -14,27 +14,15 @@ import { ShadowDomContainer } from './components/ShadowDomContainer';
 
 const containerId = 'jupiter-plugin-instance';
 const packageJson = require('../package.json');
+const bundleName = `plugin-${packageJson.version}`;
 
-// Use stable bundle name in dev mode OR Vercel preview to avoid CDN version mismatch
-const isPluginDev = process.env.NEXT_PUBLIC_IS_PLUGIN_DEV === 'true';
+// In dev/preview: load from local /public (empty string = relative path)
+// In production: load from CDN
+const isLocalDev = process.env.NEXT_PUBLIC_IS_PLUGIN_DEV === 'true';
 const isVercelPreview = process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview';
-const useDevBundle = isPluginDev || isVercelPreview;
+const useLocalBundle = isLocalDev || isVercelPreview;
 
-const bundleName = useDevBundle ? 'plugin-dev' : `plugin-${packageJson.version}`;
-
-const scriptDomain =
-  (() => {
-    if (!process.env.NEXT_PUBLIC_IS_PLUGIN_DEV) {
-         return null
-    }
-    if (typeof window === 'undefined' || typeof document === 'undefined') return '';
-    
-    const url = (document.currentScript as HTMLScriptElement)?.src;
-    if (url) {
-      return new URL(url).origin;
-    }
-    return null;
-  })() || 'https://plugin.jup.ag';
+const scriptDomain = useLocalBundle ? '' : 'https://plugin.jup.ag';
 
 async function loadRemote(id: string, href: string, type: 'text/javascript' | 'stylesheet') {
   return new Promise((res, rej) => {

--- a/src/library.tsx
+++ b/src/library.tsx
@@ -15,10 +15,12 @@ import { ShadowDomContainer } from './components/ShadowDomContainer';
 const containerId = 'jupiter-plugin-instance';
 const packageJson = require('../package.json');
 
-// Use stable name in dev mode to avoid CDN version mismatch
-const bundleName = process.env.NEXT_PUBLIC_IS_PLUGIN_DEV 
-  ? 'plugin-dev' 
-  : `plugin-${packageJson.version}`;
+// Use stable bundle name in dev mode OR Vercel preview to avoid CDN version mismatch
+const isPluginDev = process.env.NEXT_PUBLIC_IS_PLUGIN_DEV === 'true';
+const isVercelPreview = process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview';
+const useDevBundle = isPluginDev || isVercelPreview;
+
+const bundleName = useDevBundle ? 'plugin-dev' : `plugin-${packageJson.version}`;
 
 const scriptDomain =
   (() => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm build-widget:dev && pnpm build",
+  "framework": "nextjs"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm build-widget:dev && pnpm build",
+  "buildCommand": "pnpm build-widget && pnpm build",
   "framework": "nextjs"
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,10 +8,13 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const packageJson = require("./package.json");
 
 const analyseBundle = process.env.ANALYSE === 'true';
-const isPluginDev = process.env.NEXT_PUBLIC_IS_PLUGIN_DEV === 'true';
 
-// Use stable name in dev mode to avoid CDN version mismatch
-const bundleName = isPluginDev ? 'plugin-dev' : `plugin-${packageJson.version}`;
+// Use stable bundle name in dev mode OR Vercel preview to avoid CDN version mismatch
+const isPluginDev = process.env.NEXT_PUBLIC_IS_PLUGIN_DEV === 'true';
+const isVercelPreview = process.env.VERCEL_ENV === 'preview';
+const useDevBundle = isPluginDev || isVercelPreview;
+
+const bundleName = useDevBundle ? 'plugin-dev' : `plugin-${packageJson.version}`;
 
 if (!bundleName) {
   throw new Error('Bundle name/version is not set');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,12 +9,8 @@ const packageJson = require("./package.json");
 
 const analyseBundle = process.env.ANALYSE === 'true';
 
-// Use stable bundle name in dev mode OR Vercel preview to avoid CDN version mismatch
-const isPluginDev = process.env.NEXT_PUBLIC_IS_PLUGIN_DEV === 'true';
-const isVercelPreview = process.env.VERCEL_ENV === 'preview';
-const useDevBundle = isPluginDev || isVercelPreview;
-
-const bundleName = useDevBundle ? 'plugin-dev' : `plugin-${packageJson.version}`;
+// Always use versioned bundle name
+const bundleName = `plugin-${packageJson.version}`;
 
 if (!bundleName) {
   throw new Error('Bundle name/version is not set');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,10 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const packageJson = require("./package.json");
 
 const analyseBundle = process.env.ANALYSE === 'true';
-const bundleName = `plugin-${packageJson.version}`;
+const isPluginDev = process.env.NEXT_PUBLIC_IS_PLUGIN_DEV === 'true';
+
+// Use stable name in dev mode to avoid CDN version mismatch
+const bundleName = isPluginDev ? 'plugin-dev' : `plugin-${packageJson.version}`;
 
 if (!bundleName) {
   throw new Error('Bundle name/version is not set');


### PR DESCRIPTION
## Problem
When bumping `package.json` version during development, the homepage breaks because:
1. `bundleName` becomes `plugin-{new-version}`
2. Loader tries to fetch `plugin-{new-version}-app.js` from CDN
3. File doesn't exist on CDN yet → 💥

This forced developers to either:
- Not bump versions until ready to publish
- Or deal with a broken homepage during development

## Solution
When `NEXT_PUBLIC_IS_PLUGIN_DEV=true`:
- Webpack outputs to `plugin-dev.js` (stable name)
- Runtime loader uses `plugin-dev.js` 
- Version bumps no longer break local development

## Usage

```bash
# In .env (already enabled by default after this PR)
NEXT_PUBLIC_IS_PLUGIN_DEV=true

# Build for local testing
pnpm build-widget
# → outputs plugin-dev.js, plugin-dev-app.js, etc.

# Build for production (when ready to publish)
NEXT_PUBLIC_IS_PLUGIN_DEV= pnpm build-widget  
# → outputs plugin-1.0.14.js, etc.
```

## Changes
- **webpack.config.js**: Use `plugin-dev` bundle name when dev flag is set
- **library.tsx**: Same logic for runtime bundle resolution
- **.env**: Enable dev mode by default
- **DEVELOPER_NOTES.md**: Document the workflow

## Backwards Compatible
Production builds (without the env var) work exactly as before.